### PR TITLE
ファイルサイズ削減

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,10 +20,4 @@
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
-	<!-- 不要なリソース・言語ファイルを除外 -->
-	<ItemGroup>
-		<!-- ロケール言語パックを除去 -->
-		<SatelliteResourceLanguages Remove="de;fr;es;it;ru;zh-Hans;zh-Hant;*" />
-		<!-- Vosk や VoiceVox 用の巨大ファイルは手動でコピー管理 -->
-	</ItemGroup>
 </Project>

--- a/ETS2_FerryAssist.csproj
+++ b/ETS2_FerryAssist.csproj
@@ -10,12 +10,12 @@
 
 		<PlatformTarget>x64</PlatformTarget>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
-		<SelfContained>true</SelfContained>
+		<SelfContained>false</SelfContained>
 		<PublishSingleFile>true</PublishSingleFile>
 		<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
 		<IncludeAllContentForSelfExtract>false</IncludeAllContentForSelfExtract>
 		<InvariantGlobalization>true</InvariantGlobalization>
-		<EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+		<EnableCompressionInSingleFile>false</EnableCompressionInSingleFile>
 		<PublishReadyToRun>false</PublishReadyToRun>
 
 		<DebugType>embedded</DebugType>
@@ -39,7 +39,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="NAudio" Version="2.2.1" />
-		<PackageReference Include="System.Data.SQLite" Version="1.0.119" />
+		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
 		<PackageReference Include="Vosk" Version="0.3.38" />
 	</ItemGroup>
 


### PR DESCRIPTION
リリースファイルサイズを削減するための変更です。
1. EF Core は未使用であるため、SQLite の NuGet パッケージを System.Data.SQLite.Core に変更
2. .csproj の SelfContained、EnableCompressionInSingleFile を false にし、ランタイムのアセンブリと言語リソースファイルが出力されないように
3. 2. で言語リソースファイルが出力されなくなったので、 Directory.Build.props の言語リソースフォルダ削除の記述を削除


ETS2_FerryAssist.exe のサイズ
| 修正前 | 修正後 |
|----------|----------|
| 84.3 MB | 48.7 MB |

ヨシ！ ヾ(•ω•`)o